### PR TITLE
Remove redundant npm dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,6 @@
     "install": "^0.12.2",
     "moment": "^2.24.0",
     "moment-timer": "^1.3.0",
-    "npm": "^6.9.0",
     "react": "^16.8.6",
     "react-dom": "^16.8.6",
     "react-scripts": "3.0.1"


### PR DESCRIPTION

Hello Bedrock02!

It seems like you have npm as one of your (dev-) dependency in HotColdTherapy.
Since you actually need npm to install the dependencies it's redundant to
have npm itself as (dev-) dependency. 

Therefore I've removed it and made this PR, merge if you want :)
Be sure to re-run `npm i` or `yarn` to actualize your lock files.

Beep boop, I'm a bot.
